### PR TITLE
Add support for teams for pr reviewers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "pr_opener"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "console",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr_opener"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,20 @@ fn get_pr_body(overview: &str, context: &str) -> String {
 }
 
 fn fetch_github_reviewers() -> Vec<String> {
-    let gh_users = Command::new("gh")
+    let gh_team_users_output = Command::new("gh")
+        .arg("api")
+        .arg("orgs/dittowords/teams")
+        .arg("--jq")
+        .arg(".[].slug")
+        .output()
+        .unwrap();
+
+    let gh_team_users = String::from_utf8_lossy(&gh_team_users_output.stdout)
+        .split_whitespace()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+    let gh_users_output = Command::new("gh")
         .arg("api")
         .arg("orgs/dittowords/members")
         .arg("--jq")
@@ -248,12 +261,12 @@ fn fetch_github_reviewers() -> Vec<String> {
         .output()
         .unwrap();
 
-    let gh_users = String::from_utf8_lossy(&gh_users.stdout)
+    let gh_users = String::from_utf8_lossy(&gh_users_output.stdout)
         .split_whitespace()
         .map(String::from)
         .collect::<Vec<String>>();
 
-    gh_users
+    [gh_team_users, gh_users].concat()
 }
 
 


### PR DESCRIPTION
Adds support for pulling in teams specific to the dittowords org. This will allow us to select ditto-engineers as a reviewer with the pr tool.